### PR TITLE
Fix hardcoded localhost:3000 — use BACKEND_URL everywhere

### DIFF
--- a/admin/client.html
+++ b/admin/client.html
@@ -311,7 +311,7 @@
 const tbodyNew = document.querySelector('table tbody');
 
 async function loadClients() {
-  const res  = await fetch('http://localhost:3000/clients');
+  const res  = await fetch(`${BACKEND_URL}/clients`);
   const json = await res.json();
   renderClients(json.data || []);
 }
@@ -338,7 +338,7 @@ function renderClients(clients) {
 
 async function refreshAll() {
   showToast('Refreshing all clients...', 'info');
-  const res  = await fetch('http://localhost:3000/clients/refresh-all', { method: 'POST' });
+  const res  = await fetch(`${BACKEND_URL}/clients/refresh-all`, { method: 'POST' });
   const json = await res.json();
   (json.data || []).forEach(c => {
     const marginEl = document.getElementById(`margin_${c.id}`);
@@ -356,8 +356,8 @@ document.addEventListener('click', async (e) => {
 
   try {
     const [fundsRes, pnlRes] = await Promise.all([
-      fetch(`http://localhost:3000/clients/${id}/funds`).then(r => r.json()),
-      fetch(`http://localhost:3000/clients/${id}/pnl`).then(r => r.json()),
+      fetch(`${BACKEND_URL}/clients/${id}/funds`).then(r => r.json()),
+      fetch(`${BACKEND_URL}/clients/${id}/pnl`).then(r => r.json()),
     ]);
 
     const margin = fundsRes?.data?.equity?.available_margin ?? 0;

--- a/assets/js/instrument-search.001.js
+++ b/assets/js/instrument-search.001.js
@@ -3,7 +3,9 @@
 // so each page can handle the selection differently.
 
 (function () {
-  const BACKEND_URL = 'http://localhost:3000';
+  const BACKEND_URL = (typeof window !== 'undefined' && window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1')
+    ? 'https://wormless-interseptal-melodee.ngrok-free.dev'
+    : 'http://localhost:3000';
 
   function highlightText(text, query) {
     const safe = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/assets/js/load-client.001.js
+++ b/assets/js/load-client.001.js
@@ -2,7 +2,7 @@ let linked_clients = [];
 
 async function loadLinkedClients() {
   try {
-    const res = await fetch('http://localhost:3000/clients');
+    const res = await fetch(`${BACKEND_URL}/clients`);
     const json = await res.json();
     linked_clients = json.data || [];
   } catch (err) {


### PR DESCRIPTION
load-client.001.js, instrument-search.001.js and client.html were all still calling localhost:3000 directly, breaking the production site.