### PR TITLE
Add ngrok-skip-browser-warning header to all fetch requests

### DIFF
--- a/admin/client.html
+++ b/admin/client.html
@@ -338,7 +338,7 @@ function renderClients(clients) {
 
 async function refreshAll() {
   showToast('Refreshing all clients...', 'info');
-  const res  = await fetch(`${BACKEND_URL}/clients/refresh-all`, { method: 'POST' });
+  const res  = await fetch(`${BACKEND_URL}/clients/refresh-all`, { method: 'POST', headers: { 'ngrok-skip-browser-warning': 'true' } });
   const json = await res.json();
   (json.data || []).forEach(c => {
     const marginEl = document.getElementById(`margin_${c.id}`);
@@ -356,8 +356,8 @@ document.addEventListener('click', async (e) => {
 
   try {
     const [fundsRes, pnlRes] = await Promise.all([
-      fetch(`${BACKEND_URL}/clients/${id}/funds`).then(r => r.json()),
-      fetch(`${BACKEND_URL}/clients/${id}/pnl`).then(r => r.json()),
+      fetch(`${BACKEND_URL}/clients/${id}/funds`, { headers: { 'ngrok-skip-browser-warning': 'true' } }).then(r => r.json()),
+      fetch(`${BACKEND_URL}/clients/${id}/pnl`, { headers: { 'ngrok-skip-browser-warning': 'true' } }).then(r => r.json()),
     ]);
 
     const margin = fundsRes?.data?.equity?.available_margin ?? 0;

--- a/assets/js/helpers/upstox-helper.001.js
+++ b/assets/js/helpers/upstox-helper.001.js
@@ -3,6 +3,7 @@ const BACKEND_URL = window.location.hostname === 'localhost' || window.location.
   : 'https://wormless-interseptal-melodee.ngrok-free.dev';
 
 async function api(path, options = {}) {
+  options.headers = { 'ngrok-skip-browser-warning': 'true', ...options.headers };
   const res = await fetch(`${BACKEND_URL}${path}`, options);
   return res.json();
 }

--- a/assets/js/instrument-search.001.js
+++ b/assets/js/instrument-search.001.js
@@ -45,7 +45,7 @@
     async function search(query) {
       try {
         const params = new URLSearchParams({ query, records: 30, page_number: 1 });
-        const res    = await fetch(`${BACKEND_URL}/market/search?${params}`);
+        const res    = await fetch(`${BACKEND_URL}/market/search?${params}`, { headers: { 'ngrok-skip-browser-warning': 'true' } });
         const json   = await res.json();
         const items  = json.data || [];
 

--- a/assets/js/load-client.001.js
+++ b/assets/js/load-client.001.js
@@ -2,7 +2,7 @@ let linked_clients = [];
 
 async function loadLinkedClients() {
   try {
-    const res = await fetch(`${BACKEND_URL}/clients`);
+    const res = await fetch(`${BACKEND_URL}/clients`, { headers: { 'ngrok-skip-browser-warning': 'true' } });
     const json = await res.json();
     linked_clients = json.data || [];
   } catch (err) {


### PR DESCRIPTION
ngrok intercepts browser fetch requests and returns its own warning page (no CORS headers) unless the request includes this header.