### PR TITLE
Real-time price feed via SSE + configurable trading limit % in client UI

### DIFF
--- a/admin/client.html
+++ b/admin/client.html
@@ -131,6 +131,7 @@
             <th>Stock Broker</th>
             <th>Total PnL</th>
             <th>Margin Available</th>
+            <th>Limit %</th>
             <th>Client Status</th>
             <th>Action</th>
           </tr>

--- a/admin/dashboard.html
+++ b/admin/dashboard.html
@@ -122,10 +122,8 @@
       <th>Symbol</th>
       <th>Lot Size</th>
       <th>Instrument Key</th>
-      <th>Current Price</th>
-      <!-- <th>Bought At</th>
-      <th>Exit At</th>
-      <th>Profit/Loss</th> -->
+      <th>LTP</th>
+      <th>Change</th>
       <th>Action</th>
     </tr>
   </thead>

--- a/assets/js/client-list.001.js
+++ b/assets/js/client-list.001.js
@@ -14,6 +14,13 @@ function renderClients(clients) {
       <td id="pnl_${c.id}">—</td>
       <td id="margin_${c.id}">—</td>
       <td>
+        <div class="input-group input-group-sm" style="width:110px;">
+          <input type="number" class="form-control limit-input" min="1" max="100"
+            data-id="${c.id}" value="${c.trading_limit_pct ?? 90}" title="% of margin to use">
+          <span class="input-group-text">%</span>
+        </div>
+      </td>
+      <td>
         <span class="badge ${c.active ? 'bg-success' : 'bg-secondary'}">${c.active ? 'Active' : 'Inactive'}</span>
       </td>
       <td>
@@ -62,6 +69,22 @@ document.addEventListener('click', async (e) => {
   } finally {
     btn.disabled = false;
     btn.innerHTML = '<i class="bi bi-arrow-clockwise"></i> Refresh';
+  }
+});
+
+// Save trading limit on blur (when user tabs out or clicks away)
+document.addEventListener('change', async (e) => {
+  const input = e.target.closest('.limit-input');
+  if (!input) return;
+  const id  = input.dataset.id;
+  const pct = Number(input.value);
+  if (!pct || pct < 1 || pct > 100) { input.classList.add('is-invalid'); return; }
+  input.classList.remove('is-invalid');
+  try {
+    await updateTradingLimit(id, pct);
+    showToast(`Margin limit updated to ${pct}%`, 'success');
+  } catch (err) {
+    showToast('Failed to save limit: ' + err.message, 'error');
   }
 });
 

--- a/assets/js/helpers/upstox-helper.001.js
+++ b/assets/js/helpers/upstox-helper.001.js
@@ -57,6 +57,47 @@ async function fetchOrderDetails(orderId, clientId) {
   return api(`/orders/details?order_id=${orderId}&client_id=${clientId}`);
 }
 
+// ── Trading limit ─────────────────────────────────────────────────────────────
+async function updateTradingLimit(clientId, pct) {
+  return api(`/clients/${clientId}/trading-limit`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ trading_limit_pct: pct }),
+  });
+}
+
+// ── Real-time price feed (SSE via fetch — EventSource can't send custom headers) ──
+function startPriceFeed(onPrice) {
+  async function connect() {
+    try {
+      const res = await fetch(`${BACKEND_URL}/market/stream`, {
+        headers: { 'ngrok-skip-browser-warning': 'true' },
+      });
+      if (!res.ok || !res.body) throw new Error(`SSE ${res.status}`);
+
+      const reader  = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop(); // keep partial last line
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try { onPrice(JSON.parse(line.slice(6))); } catch {}
+        }
+      }
+    } catch (err) {
+      console.warn('[SSE] disconnected, reconnecting in 4s:', err.message);
+    }
+    setTimeout(connect, 4_000);
+  }
+  connect();
+}
+
 // ── Watchlist (replaces IndexedDB) ────────────────────────────────────────────
 async function getWatchlist() {
   return api('/watchlist');

--- a/assets/js/populate-stocks.001.js
+++ b/assets/js/populate-stocks.001.js
@@ -3,6 +3,14 @@ function formatPrice(value) {
   return Number(value).toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
+function formatChange(ltp, cp) {
+  if (!ltp || !cp || cp === 0) return '';
+  const pct   = ((ltp - cp) / cp) * 100;
+  const sign  = pct >= 0 ? '+' : '';
+  const color = pct >= 0 ? 'text-success' : 'text-danger';
+  return `<small class="${color}">${sign}${pct.toFixed(2)}%</small>`;
+}
+
 async function populateTable() {
   const res         = await getWatchlist();
   const instruments = res?.data || [];
@@ -10,20 +18,18 @@ async function populateTable() {
   tbody.innerHTML   = '';
 
   instruments.forEach((stock) => {
-    const detailsKey = Object.keys(stock.details || {})[0];
-    const lastPrice  = detailsKey ? stock.details[detailsKey]?.last_price : null;
-
     const row = document.createElement('tr');
+    row.dataset.key = stock.instrument_key;
     row.innerHTML = `
       <td><input type="checkbox"></td>
       <td>${stock.trading_symbol}</td>
       <td>${stock.lot_size}</td>
       <td>${stock.instrument_key}</td>
-      <td class="latest-price">${formatPrice(lastPrice)}</td>
+      <td class="latest-price fw-semibold">—</td>
+      <td class="price-change">—</td>
       <td class="actions">
         <button class="btn btn-sm btn-success"  data-action="buy">Buy</button>
         <button class="btn btn-sm btn-warning"  data-action="exit">Exit</button>
-        <button class="btn btn-sm btn-info"     data-action="refresh">Refresh</button>
         <button class="btn btn-sm btn-danger"   data-action="delete">Delete</button>
       </td>
     `;
@@ -33,6 +39,13 @@ async function populateTable() {
   document.getElementById('select-all').addEventListener('change', function () {
     document.querySelectorAll('#marketTableBody input[type="checkbox"]')
       .forEach(cb => { cb.checked = this.checked; });
+  });
+
+  startPriceFeed(({ key, ltp, cp }) => {
+    const row = document.querySelector(`#marketTableBody tr[data-key="${CSS.escape(key)}"]`);
+    if (!row) return;
+    row.querySelector('.latest-price').textContent = formatPrice(ltp);
+    row.querySelector('.price-change').innerHTML   = formatChange(ltp, cp);
   });
 }
 


### PR DESCRIPTION
- upstox-helper.001.js: add startPriceFeed() (fetch-based SSE, auto-reconnect, works behind ngrok), add updateTradingLimit() for PATCH endpoint
- populate-stocks.001.js: add data-key attr to rows, call startPriceFeed() after table render, show LTP + change % columns with green/red colouring
- client-list.001.js: editable trading_limit_pct input per client row, saves on change via updateTradingLimit()
- dashboard.html: update table headers (LTP / Change / Action)
- client.html: add Limit % column header