### PR TITLE
Fix symbol parser for compact BSE format + EXIT orange + structured o…

### DIFF
--- a/admin/orders.html
+++ b/admin/orders.html
@@ -124,8 +124,10 @@
         <thead>
           <tr>
             <th>S. No.</th>
-            <th>Symbol</th>
-            <th>Type</th>
+            <th>Underlying</th>
+            <th>Strike</th>
+            <th>C / P</th>
+            <th>BUY / EXIT</th>
             <th>Qty @ Price</th>
             <th>Time</th>
             <th>Status</th>
@@ -133,7 +135,7 @@
           </tr>
         </thead>
         <tbody id="orders-tbody">
-          <tr><td colspan="7" class="text-center py-4">Loading...</td></tr>
+          <tr><td colspan="9" class="text-center py-4">Loading...</td></tr>
         </tbody>
       </table>
 

--- a/assets/js/orders-page.001.js
+++ b/assets/js/orders-page.001.js
@@ -1,6 +1,37 @@
 const clientSelect = document.getElementById('clientOptions');
 const ordersTbody  = document.getElementById('orders-tbody');
 
+function parseSymbol(sym) {
+  if (!sym) return { underlying: '—', strike: '—', optionType: '—' };
+  const u = sym.toUpperCase();
+
+  // Spaced BSE format: "SENSEX 74000 PE 14 MAY 26"
+  const spaced = u.match(/^([A-Z0-9]+)\s+(\d+)\s+(CE|PE)\b/);
+  if (spaced) return { underlying: spaced[1], strike: Number(spaced[2]).toLocaleString('en-IN'), optionType: spaced[3] };
+
+  // NSE with month name: "NIFTY25MAY25000CE", "BANKNIFTY25MAY50000PE"
+  const nseMonth = u.match(/^([A-Z]+)\d{2}[A-Z]{3}(\d+)(CE|PE)$/);
+  if (nseMonth) return { underlying: nseMonth[1], strike: Number(nseMonth[2]).toLocaleString('en-IN'), optionType: nseMonth[3] };
+
+  // BSE/NSE compact: "SENSEX2651474000PE" — format is UNDERLYING + YYMDD or YYMMDD + STRIKE + CE/PE
+  // Date is 5 digits (month 1–9) or 6 digits (month 10–12); detect by range-checking the strike
+  const compact = u.match(/^([A-Z]+)(\d+)(CE|PE)$/);
+  if (compact) {
+    const digits = compact[2];
+    for (const skip of [5, 6]) {
+      if (digits.length > skip) {
+        const candidate = Number(digits.slice(skip));
+        if (candidate >= 1000 && candidate <= 300000) {
+          return { underlying: compact[1], strike: candidate.toLocaleString('en-IN'), optionType: compact[3] };
+        }
+      }
+    }
+    return { underlying: compact[1], strike: '—', optionType: compact[3] };
+  }
+
+  return { underlying: sym, strike: '—', optionType: '—' };
+}
+
 async function initOrdersPage() {
   const res     = await loadClients();
   const clients = res.data || [];
@@ -26,34 +57,41 @@ async function initOrdersPage() {
 async function loadOrders() {
   const clientId = clientSelect.value;
   if (!clientId) {
-    ordersTbody.innerHTML = `<tr><td colspan="7" class="text-center py-4">Please select a client to view orders</td></tr>`;
+    ordersTbody.innerHTML = `<tr><td colspan="9" class="text-center py-4">Please select a client to view orders</td></tr>`;
     return;
   }
 
-  ordersTbody.innerHTML = `<tr><td colspan="7" class="text-center py-3"><div class="spinner-border spinner-border-sm"></div> Loading...</td></tr>`;
+  ordersTbody.innerHTML = `<tr><td colspan="9" class="text-center py-3"><div class="spinner-border spinner-border-sm"></div> Loading...</td></tr>`;
 
   try {
     const res    = await getClientOrders(clientId);
     const orders = res?.data || [];
 
     if (orders.length === 0) {
-      ordersTbody.innerHTML = `<tr><td colspan="7" class="text-center py-4">No orders found for today</td></tr>`;
+      ordersTbody.innerHTML = `<tr><td colspan="9" class="text-center py-4">No orders found for today</td></tr>`;
       return;
     }
 
     ordersTbody.innerHTML = orders.map((o, i) => {
+      const { underlying, strike, optionType } = parseSymbol(o.trading_symbol);
       const statusClass = o.status === 'complete'  ? 'bg-success' :
                           o.status === 'rejected'  ? 'bg-danger'  :
                           o.status === 'cancelled' ? 'bg-secondary' : 'bg-warning text-dark';
-      const txClass = o.transaction_type === 'BUY' ? 'text-success fw-bold' : 'text-danger fw-bold';
+      const isBuyRow  = o.transaction_type === 'BUY';
+      const txStyle   = isBuyRow ? 'color:#27ae60' : 'color:#e67e22';
+      const txLabel   = isBuyRow ? 'BUY' : 'EXIT';
+      const cpColor   = optionType === 'CE' ? '#27ae60' : '#e67e22';
+      const cpLabel   = optionType === 'CE' ? 'CALL' : optionType === 'PE' ? 'PUT' : optionType;
 
       return `
         <tr>
           <td>${i + 1}</td>
-          <td>${o.trading_symbol || '—'}</td>
-          <td><span class="${txClass}">${o.transaction_type || '—'}</span></td>
+          <td class="fw-semibold">${underlying}</td>
+          <td class="fw-semibold">₹${strike}</td>
+          <td><span class="badge" style="background:${cpColor}">${cpLabel}</span></td>
+          <td><span class="fw-bold" style="${txStyle}">${txLabel}</span></td>
           <td>${o.quantity || 0} @ ₹${Number(o.average_price || o.price || 0).toFixed(2)}</td>
-          <td>${o.order_timestamp ? new Date(o.order_timestamp).toLocaleString('en-IN', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit', hour12: true }) : '—'}</td>
+          <td class="text-muted small">${o.order_timestamp ? new Date(o.order_timestamp).toLocaleString('en-IN', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit', hour12: true }) : '—'}</td>
           <td><span class="badge ${statusClass}">${(o.status || '—').toUpperCase()}</span></td>
           <td>
             <button class="btn btn-sm btn-outline-secondary view-details"
@@ -66,7 +104,7 @@ async function loadOrders() {
     }).join('');
 
   } catch (err) {
-    ordersTbody.innerHTML = `<tr><td colspan="7" class="text-center text-danger py-4">Failed to load orders: ${err.message}</td></tr>`;
+    ordersTbody.innerHTML = `<tr><td colspan="9" class="text-center text-danger py-4">Failed to load orders: ${err.message}</td></tr>`;
   }
 }
 
@@ -75,32 +113,40 @@ document.addEventListener('click', (e) => {
   if (!btn) return;
   const o = JSON.parse(btn.dataset.order);
 
+  const { underlying, strike, optionType } = parseSymbol(o.trading_symbol);
+  const cpLabel2    = optionType === 'CE' ? 'CALL' : optionType === 'PE' ? 'PUT' : optionType;
+  const cpHex       = optionType === 'CE' ? '#27ae60' : '#e67e22';
   const isBuy       = o.transaction_type === 'BUY';
+  const txLabel     = isBuy ? 'BUY' : 'EXIT';
+  const txHex       = isBuy ? '#27ae60' : '#e67e22';
+  const txIcon      = isBuy ? 'fa-arrow-trend-up' : 'fa-right-from-bracket';
   const statusColor = o.status === 'complete'  ? 'success' :
                       o.status === 'rejected'  ? 'danger'  :
                       o.status === 'cancelled' ? 'secondary' : 'warning';
-  const txColor     = isBuy ? 'success' : 'danger';
-  const txIcon      = isBuy ? 'fa-arrow-trend-up' : 'fa-arrow-trend-down';
   const timestamp   = o.order_timestamp
     ? new Date(o.order_timestamp).toLocaleString('en-IN', { day: '2-digit', month: 'short', year: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true })
     : '—';
-  const avgPrice    = Number(o.average_price || 0).toFixed(2);
-  const limitPrice  = Number(o.price || 0).toFixed(2);
+  const avgPrice  = Number(o.average_price || 0).toFixed(2);
+  const limitPrice = Number(o.price || 0).toFixed(2);
 
   document.getElementById('orderDetailContent').innerHTML = `
     <div class="modal-header border-0 pb-0">
       <div>
-        <h5 class="modal-title fw-bold mb-1">${o.trading_symbol || 'Order Details'}</h5>
+        <h5 class="modal-title fw-bold mb-1">
+          ${underlying}
+          <span class="fs-6 fw-normal text-muted">₹${strike}</span>
+          <span class="badge ms-1" style="background:${cpHex};font-size:0.7rem">${cpLabel2}</span>
+        </h5>
         <span class="badge bg-${statusColor} text-uppercase">${o.status || '—'}</span>
       </div>
       <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
     </div>
     <div class="modal-body pt-2">
 
-      <div class="d-flex align-items-center gap-3 mb-4 p-3 rounded-3 bg-${txColor} bg-opacity-10">
-        <i class="fa-solid ${txIcon} fa-2x text-${txColor}"></i>
+      <div class="d-flex align-items-center gap-3 mb-4 p-3 rounded-3" style="background:${txHex}18">
+        <i class="fa-solid ${txIcon} fa-2x" style="color:${txHex}"></i>
         <div>
-          <div class="fw-bold fs-5 text-${txColor}">${o.transaction_type || '—'}</div>
+          <div class="fw-bold fs-5" style="color:${txHex}">${txLabel}</div>
           <div class="text-muted small">${o.order_type || '—'} order</div>
         </div>
       </div>
@@ -127,7 +173,7 @@ document.addEventListener('click', (e) => {
         <div class="col-6">
           <div class="border rounded-3 p-3 text-center">
             <div class="text-muted small mb-1">Avg Price</div>
-            <div class="fw-bold text-${txColor}">₹${avgPrice}</div>
+            <div class="fw-bold" style="color:${txHex}">₹${avgPrice}</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
…rders table

- parseSymbol handles "SENSEX2651474000PE" compact format — skip 5 or 6 date digits then range-check strike (1000-300000) to distinguish month lengths
- Table columns: Underlying | Strike | CALL/PUT | BUY/EXIT | Qty@Price | Time | Status
- SELL renamed EXIT with orange color (#e67e22) in both table and modal
- Modal header shows "SENSEX ₹74,000 [PUT]" badge