### PR TITLE
Add historical orders lookup for past dates

### DIFF
--- a/assets/js/helpers/upstox-helper.001.js
+++ b/assets/js/helpers/upstox-helper.001.js
@@ -55,6 +55,9 @@ async function refreshClient(clientId) {
 async function getClientOrders(clientId) {
   return api(`/clients/${clientId}/orders`);
 }
+async function getClientOrderHistory(clientId, date) {
+  return api(`/clients/${clientId}/orders/history?date=${date}`);
+}
 
 // ── Orders ────────────────────────────────────────────────────────────────────
 async function placeBuyOrder(instrumentKey, lotSize, currentPrice) {

--- a/assets/js/orders-page.001.js
+++ b/assets/js/orders-page.001.js
@@ -68,7 +68,7 @@ async function initOrdersPage() {
   }
 
   clientSelect.addEventListener('change', () => { updatePlatformBadge(); loadOrders(); });
-  dateInput.addEventListener('change', applyDateFilter);
+  dateInput.addEventListener('change', loadOrders);
   updatePlatformBadge();
   loadOrders();
 }
@@ -216,7 +216,14 @@ async function loadOrders() {
   summaryEl.innerHTML = '';
 
   try {
-    const res = await getClientOrders(clientId);
+    const today   = new Date().toLocaleDateString('sv');
+    const selDate = dateInput.value;
+    const isToday = !selDate || selDate === today;
+
+    const res = isToday
+      ? await getClientOrders(clientId)
+      : await getClientOrderHistory(clientId, selDate);
+
     rawOrders = (res?.data || []).slice().sort((a, b) => {
       const ta = a.order_timestamp ? new Date(a.order_timestamp).getTime() : 0;
       const tb = b.order_timestamp ? new Date(b.order_timestamp).getTime() : 0;


### PR DESCRIPTION
Today uses the live broker API; selecting a past date calls /clients/:id/orders/history?date= to serve from our trade logs.