### PR TITLE
Replace PnL column with Usable Margin, multi-platform clean display

### DIFF
--- a/admin/client.html
+++ b/admin/client.html
@@ -137,8 +137,8 @@
                   <th>S. No.</th>
                   <th>Client Name</th>
                   <th>Stock Broker</th>
-                  <th>Total PnL</th>
                   <th>Margin Available</th>
+                  <th>Usable Margin</th>
                   <th>Limit %</th>
                   <th>Client Status</th>
                   <th>Action</th>

--- a/assets/js/client-list.001.js
+++ b/assets/js/client-list.001.js
@@ -15,14 +15,19 @@ async function loadClientList() {
   else badge.style.display = 'none';
 }
 
+function usableMargin(margin, limitPct) {
+  if (margin == null) return '—';
+  return `₹${Number(margin * (limitPct ?? 90) / 100).toLocaleString('en-IN')}`;
+}
+
 function renderClients(clients) {
   tbodyNew.innerHTML = clients.map((c, i) => `
     <tr id="row_${c.id}" class="${c.active ? '' : 'opacity-50'}">
       <td>${i + 1}</td>
       <td><a href="orders.html?client_id=${c.id}">${c.client_name}</a></td>
       <td>${platformBadge(c.platform)}</td>
-      <td id="pnl_${c.id}">—</td>
       <td id="margin_${c.id}">${c.last_margin == null ? '—' : `₹${Number(c.last_margin).toLocaleString('en-IN')}`}</td>
+      <td id="usable_${c.id}">${usableMargin(c.last_margin, c.trading_limit_pct)}</td>
       <td>
         <div class="input-group input-group-sm" style="width:110px;">
           <input type="number" class="form-control limit-input" min="1" max="100"
@@ -37,7 +42,7 @@ function renderClients(clients) {
         </button>
       </td>
       <td>
-        <button class="btn btn-sm btn-primary refresh-client" data-id="${c.id}">
+        <button class="btn btn-sm btn-primary refresh-client" data-id="${c.id}" data-platform="${c.platform}" data-limit="${c.trading_limit_pct ?? 90}">
           <i class="bi bi-arrow-clockwise"></i> Refresh
         </button>
       </td>
@@ -87,8 +92,10 @@ async function refreshAll() {
   showToast('Refreshing all clients...', 'info');
   const res = await refreshAllClients();
   (res.data || []).forEach(c => {
-    const el = document.getElementById(`margin_${c.id}`);
-    if (el) el.textContent = c.available_margin != null ? `₹${Number(c.available_margin).toLocaleString('en-IN')}` : '—';
+    const marginEl = document.getElementById(`margin_${c.id}`);
+    const usableEl = document.getElementById(`usable_${c.id}`);
+    if (marginEl) marginEl.textContent = c.available_margin != null ? `₹${Number(c.available_margin).toLocaleString('en-IN')}` : '—';
+    if (usableEl) usableEl.textContent = usableMargin(c.available_margin, c.trading_limit_pct);
   });
   showToast('All clients refreshed', 'success');
 }
@@ -113,20 +120,17 @@ async function handleToggleActive(btn) {
 }
 
 async function handleRefreshClient(btn) {
-  const id = btn.dataset.id;
+  const id       = btn.dataset.id;
   btn.disabled = true;
   btn.innerHTML = '<i class="bi bi-hourglass-split"></i>';
   try {
-    const [fundsRes, pnlRes] = await Promise.all([
-      getFundsAndMargin(id),
-      getClientPnl(id),
-    ]);
-    const margin = fundsRes?.data?.equity?.available_margin ?? 0;
-    const pnl    = (pnlRes?.data || []).reduce((sum, t) => sum + ((t.sell_amount || 0) - (t.buy_amount || 0)), 0);
+    const fundsRes = await getFundsAndMargin(id);
+    const margin   = fundsRes?.data?.equity?.available_margin ?? 0;
+    const limitPct = Number(document.querySelector(`.limit-input[data-id="${id}"]`)?.value ?? btn.dataset.limit ?? 90);
     const marginEl = document.getElementById(`margin_${id}`);
-    const pnlEl    = document.getElementById(`pnl_${id}`);
+    const usableEl = document.getElementById(`usable_${id}`);
     if (marginEl) marginEl.textContent = `₹${Number(margin).toLocaleString('en-IN')}`;
-    if (pnlEl)    pnlEl.textContent    = `₹${pnl.toFixed(2)}`;
+    if (usableEl) usableEl.textContent = usableMargin(margin, limitPct);
     showToast('Client refreshed', 'success');
   } catch (err) {
     showToast('Refresh failed: ' + err.message, 'error');

--- a/assets/js/orders-page.001.js
+++ b/assets/js/orders-page.001.js
@@ -149,6 +149,7 @@ function renderPage(page) {
     const cpColor     = optionType === 'CE' ? '#27ae60' : '#e67e22';
     const cpLabel     = optionType === 'CE' ? 'CALL' : optionType === 'PE' ? 'PUT' : optionType;
     const rowTotal    = (o.quantity || 0) * (o.average_price || o.price || 0);
+    const strikeDisplay = strike === '—' ? '—' : `₹${strike}`;
     const sourceBadge = o.tag === 'moneymoose'
       ? `<span style="font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;background:#0ea5e9;color:#fff">API</span>`
       : `<span style="font-size:10px;font-weight:700;padding:2px 7px;border-radius:4px;background:#94a3b8;color:#fff">Manual</span>`;
@@ -157,7 +158,7 @@ function renderPage(page) {
       <tr>
         <td>${start + i + 1}</td>
         <td class="fw-semibold">${underlying}</td>
-        <td class="fw-semibold">₹${strike}</td>
+        <td class="fw-semibold">${strikeDisplay}</td>
         <td><span class="badge" style="background:${cpColor}">${cpLabel}</span></td>
         <td><span class="fw-bold" style="${txStyle}">${txLabel}</span></td>
         <td>${o.quantity || 0} @ ₹${Number(o.average_price || o.price || 0).toFixed(2)}</td>
@@ -249,6 +250,7 @@ document.addEventListener('click', (e) => {
   const o = JSON.parse(btn.dataset.order);
 
   const { underlying, strike, optionType } = parseSymbol(o.trading_symbol);
+  const strikeDisplay2 = strike === '—' ? '' : ` <span class="fs-6 fw-normal text-muted">₹${strike}</span>`;
   const cpLabel2    = optionType === 'CE' ? 'CALL' : optionType === 'PE' ? 'PUT' : optionType;
   const cpHex       = optionType === 'CE' ? '#27ae60' : '#e67e22';
   const isBuy       = o.transaction_type === 'BUY';
@@ -268,8 +270,7 @@ document.addEventListener('click', (e) => {
     <div class="modal-header border-0 pb-0">
       <div>
         <h5 class="modal-title fw-bold mb-1">
-          ${underlying}
-          <span class="fs-6 fw-normal text-muted">₹${strike}</span>
+          ${underlying}${strikeDisplay2}
           <span class="badge ms-1" style="background:${cpHex};font-size:0.7rem">${cpLabel2}</span>
         </h5>
         <span class="badge bg-${statusColor} text-uppercase">${o.status || '—'}</span>


### PR DESCRIPTION
- client.html: swap 'Total PnL' header for 'Usable Margin'
- client-list.001.js: usableMargin helper (margin × limit%/100); remove /pnl API call from refresh; update both margin + usable on Refresh and Refresh All; add data-limit to refresh button; Piyush auto-hidden via backend filter
- orders-page.001.js: fix '₹—' strike display in table rows and order detail modal