### PR TITLE
chore: remove auth-guard from all admin pages

### DIFF
--- a/admin/auto-trader.html
+++ b/admin/auto-trader.html
@@ -128,7 +128,6 @@
     </div>
   </div>
 
-  <script src="../assets/js/auth-guard.001.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../assets/js/api.001.js?v=0.1.0"></script>
   <script src="../assets/js/helpers/upstox-helper.001.js?v=0.1.0"></script>

--- a/admin/client.html
+++ b/admin/client.html
@@ -131,7 +131,6 @@
     </div>
   </div>
   <!-- JS -->
-  <script src="../assets/js/auth-guard.001.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../assets/js/api.001.js?v=0.1.0"></script>
   <script src="../assets/js/helpers/upstox-helper.001.js?v=0.1.0"></script>

--- a/admin/dashboard.html
+++ b/admin/dashboard.html
@@ -189,7 +189,6 @@
   <div id="ops-footer"></div>
 
   <!-- JS -->
-  <script src="../assets/js/auth-guard.001.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../assets/js/api.001.js?v=0.1.0"></script>
   <script src="../assets/js/helpers/upstox-helper.001.js?v=0.1.0"></script>

--- a/admin/orders.html
+++ b/admin/orders.html
@@ -117,7 +117,6 @@
     </div>
   </div>
   <!-- JS -->
-  <script src="../assets/js/auth-guard.001.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../assets/js/api.001.js?v=0.1.0"></script>
   <script src="../assets/js/helpers/upstox-helper.001.js?v=0.1.0"></script>

--- a/admin/report.html
+++ b/admin/report.html
@@ -194,7 +194,6 @@
   </div>
 
   <!-- JS -->
-  <script src="../assets/js/auth-guard.001.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="../assets/js/api.001.js?v=0.1.0"></script>
   <script src="../assets/js/helpers/upstox-helper.001.js?v=0.1.0"></script>


### PR DESCRIPTION
Backend auth is disabled for now — no login required.